### PR TITLE
0.1.2-2

### DIFF
--- a/backend/features/collection/collections_schema.py
+++ b/backend/features/collection/collections_schema.py
@@ -18,6 +18,7 @@ def setup_collections_tables():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             name TEXT NOT NULL,
             description TEXT,
+            content_type TEXT DEFAULT 'MANGA',
             is_default INTEGER DEFAULT 0,
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
             updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -25,12 +26,12 @@ def setup_collections_tables():
         )
         """, commit=True)
         
-        # Create a unique index to ensure only one default collection
+        # Create a unique index to ensure only one default per content_type
         # This will fail silently if the index already exists
         try:
             execute_query("""
-            CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_default 
-            ON collections(is_default) WHERE is_default = 1
+            CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_default_per_type 
+            ON collections(content_type, is_default) WHERE is_default = 1
             """, commit=True)
         except Exception as e:
             # Index might already exist, that's okay

--- a/backend/features/move_service.py
+++ b/backend/features/move_service.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Move service for series between collections and/or root folders.
+
+Phase 1: DB-only collection reassignment.
+Phase 2: Physical folder migration with dry-run.
+"""
+from typing import Dict, Optional, List
+import os
+import shutil
+from pathlib import Path
+
+from backend.base.logging import LOGGER
+from backend.internals.db import execute_query
+from backend.features.collection import get_collection_by_id
+from backend.base.helpers import get_safe_folder_name
+
+
+def _get_series(series_id: int) -> Optional[Dict]:
+    rows = execute_query("SELECT * FROM series WHERE id = ?", (series_id,))
+    return rows[0] if rows else None
+
+
+def _get_series_collections(series_id: int) -> List[Dict]:
+    return execute_query(
+        """
+        SELECT c.* FROM collections c
+        JOIN series_collections sc ON sc.collection_id = c.id
+        WHERE sc.series_id = ?
+        ORDER BY c.content_type, c.name
+        """,
+        (series_id,),
+    )
+
+
+def move_series_db_only(
+    series_id: int,
+    target_collection_id: Optional[int] = None,
+) -> Dict:
+    """
+    Reassign a series to a target collection (DB-only).
+
+    - Ensures the target collection exists and is in a compatible content_type bucket.
+    - Removes existing series_collections links for collections of the same bucket.
+    - Adds link to the target collection.
+
+    Returns summary dict with before/after collection memberships.
+    """
+    series = _get_series(series_id)
+    if not series:
+        raise ValueError(f"Series with id {series_id} not found")
+
+    before = _get_series_collections(series_id)
+
+    if target_collection_id is None:
+        LOGGER.info("No target_collection_id provided; returning current memberships")
+        return {"series_id": series_id, "before": before, "after": before, "changed": False}
+
+    target = get_collection_by_id(int(target_collection_id))
+    if not target:
+        raise ValueError(f"Target collection {target_collection_id} not found")
+
+    # Enforce same bucket as the series' content_type
+    series_bucket = (series.get("content_type") or "MANGA").upper()
+    target_bucket = (target.get("content_type") or "MANGA").upper()
+    if series_bucket != target_bucket:
+        raise ValueError(
+            f"Bucket mismatch: series bucket {series_bucket} != target collection bucket {target_bucket}"
+        )
+
+    # Remove existing links within the same bucket
+    execute_query(
+        """
+        DELETE FROM series_collections
+        WHERE series_id = ? AND collection_id IN (
+            SELECT id FROM collections WHERE UPPER(COALESCE(content_type,'MANGA')) = ?
+        )
+        """,
+        (series_id, series_bucket),
+        commit=True,
+    )
+
+    # Add link to target
+    execute_query(
+        "INSERT INTO series_collections (collection_id, series_id) VALUES (?, ?)",
+        (int(target_collection_id), series_id),
+        commit=True,
+    )
+
+    after = _get_series_collections(series_id)
+    return {"series_id": series_id, "before": before, "after": after, "changed": True}
+
+
+def _pick_collection_root_path(collection_id: int) -> Optional[Path]:
+    rows = execute_query(
+        """
+        SELECT rf.path FROM root_folders rf
+        JOIN collection_root_folders crf ON rf.id = crf.root_folder_id
+        WHERE crf.collection_id = ?
+        ORDER BY rf.name ASC
+        """,
+        (collection_id,),
+    )
+    if rows:
+        return Path(rows[0]["path"])  # first by name
+    return None
+
+
+def _get_root_path_by_id(root_folder_id: int) -> Optional[Path]:
+    rows = execute_query("SELECT path FROM root_folders WHERE id = ?", (root_folder_id,))
+    if rows:
+        return Path(rows[0]["path"])  # type: ignore
+    return None
+
+
+def _current_series_dir(series: Dict, collection_root_path: Optional[Path]) -> Path:
+    # Prefer custom_path if set
+    custom_path = series.get("custom_path")
+    if custom_path:
+        return Path(custom_path)
+
+    # Fall back to computed path from collection root (or best-effort)
+    safe_title = get_safe_folder_name(series.get("title") or f"series_{series['id']}")
+    if collection_root_path:
+        return collection_root_path / safe_title
+
+    # Last resort: attempt from any configured root folder of same bucket
+    rows = execute_query(
+        """
+        SELECT rf.path FROM root_folders rf
+        WHERE UPPER(COALESCE(rf.content_type,'MANGA')) = ?
+        ORDER BY rf.name ASC
+        LIMIT 1
+        """,
+        ((series.get("content_type") or "MANGA").upper(),),
+    )
+    if rows:
+        return Path(rows[0]["path"]) / safe_title
+
+    # Default to data ebooks directory-like fallback (do not import here to avoid side effects)
+    return Path(os.getcwd()) / safe_title
+
+
+def plan_series_move(
+    series_id: int,
+    target_collection_id: Optional[int] = None,
+    target_root_folder_id: Optional[int] = None,
+    move_files: bool = False,
+    clear_custom_path: bool = False,
+    dry_run: bool = False,
+) -> Dict:
+    """Plan and optionally execute a series move.
+
+    Returns a plan dict. If not dry_run and move_files or collection change requested,
+    applies the DB changes and file moves.
+    """
+    series = _get_series(series_id)
+    if not series:
+        raise ValueError(f"Series with id {series_id} not found")
+
+    series_bucket = (series.get("content_type") or "MANGA").upper()
+
+    # Determine before state
+    before_memberships = _get_series_collections(series_id)
+
+    # Resolve target collection
+    target_collection = None
+    if target_collection_id is not None:
+        target_collection = get_collection_by_id(int(target_collection_id))
+        if not target_collection:
+            raise ValueError(f"Target collection {target_collection_id} not found")
+        target_bucket = (target_collection.get("content_type") or "MANGA").upper()
+        if target_bucket != series_bucket:
+            raise ValueError(
+                f"Bucket mismatch: series bucket {series_bucket} != target collection bucket {target_bucket}"
+            )
+
+    # Determine source and target directories
+    source_collection_path: Optional[Path] = None
+    # Try to infer current collection id within same bucket for computing source dir
+    current_bucket_collection = next((c for c in before_memberships if (c.get("content_type") or "MANGA").upper() == series_bucket), None)
+    if current_bucket_collection:
+        source_collection_path = _pick_collection_root_path(current_bucket_collection["id"])  # type: ignore
+
+    source_dir = _current_series_dir(series, source_collection_path)
+
+    target_root_path: Optional[Path] = None
+    if target_root_folder_id is not None:
+        target_root_path = _get_root_path_by_id(int(target_root_folder_id))
+        if target_root_path is None:
+            raise ValueError(f"Target root folder {target_root_folder_id} not found")
+    elif target_collection is not None:
+        target_root_path = _pick_collection_root_path(target_collection["id"])  # type: ignore
+
+    # Compute target directory only if we have a target root path and files move
+    safe_title = get_safe_folder_name(series.get("title") or f"series_{series['id']}")
+    target_dir = target_root_path / safe_title if target_root_path else None
+
+    # Build plan
+    plan: Dict = {
+        "series_id": series_id,
+        "series_bucket": series_bucket,
+        "move_files": bool(move_files and target_dir is not None),
+        "clear_custom_path": bool(clear_custom_path),
+        "source_dir": str(source_dir) if source_dir else None,
+        "target_dir": str(target_dir) if target_dir else None,
+        "before_collections": before_memberships,
+        "target_collection_id": int(target_collection_id) if target_collection_id is not None else None,
+    }
+
+    # If dry run, attempt to calculate approximate size and conflicts
+    if plan["move_files"]:
+        exists = source_dir.exists()
+        conflict = target_dir.exists() if target_dir else False
+        total_bytes = 0
+        total_files = 0
+        if exists:
+            for root, _, files in os.walk(source_dir):
+                for f in files:
+                    fp = os.path.join(root, f)
+                    try:
+                        total_bytes += os.path.getsize(fp)
+                        total_files += 1
+                    except Exception:
+                        pass
+        plan.update({
+            "source_exists": exists,
+            "target_exists": conflict,
+            "estimated_bytes": total_bytes,
+            "estimated_files": total_files,
+        })
+
+    if dry_run:
+        plan["changed"] = False
+        return plan
+
+    # Apply DB collection reassignment if requested
+    if target_collection_id is not None:
+        _ = move_series_db_only(series_id=series_id, target_collection_id=target_collection_id)
+
+    # Apply file move if requested and target is resolved
+    if plan["move_files"] and target_dir is not None:
+        target_dir_parent = target_dir.parent
+        try:
+            target_dir_parent.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            raise ValueError(f"Failed to prepare target parent directory: {target_dir_parent} ({e})")
+
+        # If target exists, abort to avoid destructive merge in MVP
+        if target_dir.exists():
+            raise ValueError(f"Target directory already exists: {target_dir}")
+
+        try:
+            LOGGER.info(f"Moving series folder from '{source_dir}' to '{target_dir}'")
+            shutil.move(str(source_dir), str(target_dir))
+        except Exception as e:
+            raise ValueError(f"Failed to move folder: {e}")
+
+        # Optionally clear custom_path if we physically moved under managed root
+        if clear_custom_path:
+            execute_query(
+                "UPDATE series SET custom_path = NULL, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
+                (series_id,),
+                commit=True,
+            )
+
+    plan["changed"] = True
+    plan["after_collections"] = _get_series_collections(series_id)
+    return plan

--- a/backend/features/scrapers/mangainfo/manga_static_db.json
+++ b/backend/features/scrapers/mangainfo/manga_static_db.json
@@ -33,5 +33,20 @@
     "chapters": 154,
     "volumes": 18,
     "title": "NINE PEAKS"
+  },
+  "gekka bijin": {
+    "chapters": 198,
+    "volumes": 5,
+    "title": "Gekka Bijin"
+  },
+  "spiderman itsuwari no aka": {
+    "chapters": 389,
+    "volumes": 1,
+    "title": "Spider-Man: Itsuwari no Aka"
+  },
+  "na honjaman level up": {
+    "chapters": 57,
+    "volumes": 19,
+    "title": "Na Honjaman Level Up"
   }
 }

--- a/backend/migrations/0012_typed_default_collections.py
+++ b/backend/migrations/0012_typed_default_collections.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Migration 0012: Add content_type to collections and enforce one default per content_type.
+
+Changes:
+- Add collections.content_type TEXT DEFAULT 'MANGA'.
+- Drop legacy unique default index if present (idx_unique_default).
+- Create partial unique index on (content_type, is_default=1): idx_unique_default_per_type.
+- Backfill content_type for existing rows using heuristics:
+  * If a collection has linked root_folders, copy the most common content_type among its root folders; else 'MANGA'.
+- Normalize defaults: ensure at most one default per content_type.
+"""
+
+from collections import Counter
+from backend.base.logging import LOGGER
+from backend.internals.db import execute_query
+
+
+def _table_exists(name: str) -> bool:
+    return bool(
+        execute_query("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (name,))
+    )
+
+
+essential_sql = {
+    "add_column": "ALTER TABLE collections ADD COLUMN content_type TEXT DEFAULT 'MANGA'",
+    "drop_old_index": "DROP INDEX IF EXISTS idx_unique_default",
+    "create_new_index": (
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_unique_default_per_type "
+        "ON collections(content_type, is_default) WHERE is_default = 1"
+    ),
+}
+
+
+def _has_column(table: str, column: str) -> bool:
+    rows = execute_query(f"PRAGMA table_info({table})")
+    return any(r.get("name") == column for r in rows)
+
+
+def _backfill_content_type():
+    rows = execute_query("SELECT id FROM collections")
+    for r in rows:
+        cid = r["id"]
+        # Find linked root folders and their content types
+        rf = execute_query(
+            """
+            SELECT rf.content_type
+            FROM root_folders rf
+            JOIN collection_root_folders crf ON crf.root_folder_id = rf.id
+            WHERE crf.collection_id = ?
+            """,
+            (cid,),
+        )
+        ctype = "MANGA"
+        if rf:
+            cnt = Counter([x.get("content_type") or "MANGA" for x in rf])
+            ctype = cnt.most_common(1)[0][0] or "MANGA"
+        execute_query(
+            "UPDATE collections SET content_type = ? WHERE id = ?",
+            (ctype, cid),
+            commit=True,
+        )
+
+
+def _normalize_defaults_per_type():
+    # Get all content types present in collections
+    types = execute_query("SELECT DISTINCT COALESCE(content_type, 'MANGA') AS ct FROM collections")
+    for t in types:
+        ct = t.get("ct") or "MANGA"
+        defs = execute_query(
+            "SELECT id FROM collections WHERE COALESCE(content_type, 'MANGA') = ? AND is_default = 1",
+            (ct,),
+        )
+        if len(defs) > 1:
+            # Keep the first, unset others
+            keep_id = defs[0]["id"]
+            execute_query(
+                "UPDATE collections SET is_default = 0 WHERE COALESCE(content_type, 'MANGA') = ? AND is_default = 1 AND id != ?",
+                (ct, keep_id),
+                commit=True,
+            )
+
+
+def migrate():
+    LOGGER.info("Running migration 0012: typed default collections")
+
+    if not _table_exists("collections"):
+        LOGGER.info("collections table not found; skipping 0012")
+        return
+
+    # 1) Add content_type column if missing
+    if not _has_column("collections", "content_type"):
+        try:
+            execute_query(essential_sql["add_column"], commit=True)
+            LOGGER.info("Added collections.content_type column")
+        except Exception as e:
+            LOGGER.error(f"Failed adding content_type column: {e}")
+            raise
+    else:
+        LOGGER.info("collections.content_type already exists; skipping add")
+
+    # 2) Backfill values
+    try:
+        _backfill_content_type()
+        LOGGER.info("Backfilled collections.content_type values")
+    except Exception as e:
+        LOGGER.error(f"Error backfilling content_type: {e}")
+        raise
+
+    # 3) Replace unique index
+    try:
+        execute_query(essential_sql["drop_old_index"], commit=True)
+    except Exception as e:
+        LOGGER.info(f"Note dropping old index: {e}")
+
+    try:
+        execute_query(essential_sql["create_new_index"], commit=True)
+        LOGGER.info("Created idx_unique_default_per_type partial unique index")
+    except Exception as e:
+        LOGGER.error(f"Error creating per-type default index: {e}")
+        raise
+
+    # 4) Normalize defaults per type (unset extra defaults)
+    try:
+        _normalize_defaults_per_type()
+        LOGGER.info("Normalized defaults per content_type")
+    except Exception as e:
+        LOGGER.error(f"Error normalizing defaults: {e}")
+        raise
+
+    LOGGER.info("Migration 0012 completed successfully")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Root Folder Selection**:
   - Visible Root Folder selector added to both flows, populated from the auto-selected default collection for the chosen bucket.
   - Users can optionally choose a specific root folder when a collection has multiple.
+ - **Series Move API**:
+  - Added `POST /api/series/{id}/move` to move a series between collections within the same bucket (DB-only, no file moves yet).
+  - Returns a summary of before/after collection memberships and whether a change occurred.
+  - **Series Move Feature**:
+  - Backend:
+    - Added [move_service.py](cci:7://file:///c:/Users/dariu/Documents/GitHub/Readloom/backend/features/move_service.py:0:0-0:0) with full move operation support (DB + filesystem)
+    - Dry-run mode to preview moves before executing
+    - Bucket compatibility validation (MANGA/COMIC/BOOK)
+  - API:
+    - Extended `POST /api/series/{id}/move` endpoint with:
+      - `target_collection_id` (required)
+      - `target_root_folder_id` (optional)
+      - `move_files` flag for physical moves
+      - `clear_custom_path` option
+      - `dry_run` mode
+  - UI:
+    - Added Move button in series header and Quick Actions
+    - Interactive Move dialog with collection/folder selectors
+    - Dry-run preview panel showing paths and conflicts
+    - Safety checks to prevent destructive overwrites
 
 ### Fixed
 - **Default Collection Handling**:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,17 +14,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Frontend wiring to `POST /api/collections/{id}/root-folders/{root_folder_id}` and auto-refresh of the table
 - **API Documentation**:
   - Documented `GET /api/collections/default` endpoint usage across the app
+- **Expanded Content Types in UI**:
+  - `frontend/templates/search.html` (Import modal) and `frontend/templates/series_list.html` (Add Series) now support: Manga, Manhwa, Manhua, Comics, Novel, Book, Other.
+  - Implemented subtype-to-bucket mapping function to group these under collection buckets: `MANGA` (Manga/Manhwa/Manhua), `COMIC` (Comics), `BOOK` (Book/Novel/Other).
+- **Root Folder Selection**:
+  - Visible Root Folder selector added to both flows, populated from the auto-selected default collection for the chosen bucket.
+  - Users can optionally choose a specific root folder when a collection has multiple.
 
 ### Fixed
 - **Default Collection Handling**:
   - Ensured only one default collection is treated as active throughout UI flows
   - Consistent Default badge display in Collections Manager
   - Safer delete behavior for default collection and clearer UX around default selection
+- **UnboundLocalError in folder path endpoint**:
+  - `frontend/api.py`: removed inner import shadowing of `execute_query` and moved `Path` import to top-level to fix "cannot access local variable 'execute_query'" error in `get_series_folder_path()`.
 
 ### Changed
 - **Docs**:
   - Updated `docs/COLLECTIONS.md` with the new Link Root Folder workflow and troubleshooting
   - Added `docs/LINK_ROOT_FOLDER.md` guide
+- **Simplified Collection Selection UX**:
+  - Collection selector is now hidden in both Import and Add Series flows and auto-selected to the single default collection per bucket.
+  - Import/Add requests now include `content_type` (the selected subtype), resolved `collection_id` (default per bucket), and optional `root_folder_id`.
+- **Type Inference on Details Modal**:
+  - Light heuristics added in `search.html` to pre-select a sensible content subtype based on title/genres/description.
 
 ## [0.1.1-1] - 2025-10-02
 

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -4,6 +4,7 @@
 import json
 from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Union
+from pathlib import Path
 
 from flask import Blueprint, Response, jsonify, request
 
@@ -16,10 +17,18 @@ from backend.base.helpers import (
 from backend.base.logging import LOGGER
 from frontend.middleware import root_folders_required
 from backend.features.calendar import get_calendar_events, update_calendar
-from backend.features.collection import (add_to_collection, export_collection,
-                                        get_collection_items, get_collection_stats,
-                                        import_collection, remove_from_collection,
-                                        update_collection_item, update_collection_stats)
+from backend.features.collection import (
+    add_to_collection,
+    export_collection,
+    get_collection_items,
+    get_collection_stats,
+    import_collection,
+    remove_from_collection,
+    update_collection_item,
+    update_collection_stats,
+    add_series_to_collection,
+    get_default_collection,
+)
 from backend.features.home_assistant import (get_home_assistant_sensor_data,
                                             get_home_assistant_setup_instructions)
 from backend.features.homarr import get_homarr_data, get_homarr_setup_instructions
@@ -203,10 +212,12 @@ def get_series_folder_path():
             if field not in data:
                 return jsonify({"error": f"Missing required field: {field}"}), 400
         
-        # Get the folder path
+        # Get the folder path inputs
         series_id = data["series_id"]
         title = data["title"]
-        content_type = data["content_type"]
+        content_type = (data.get("content_type") or "MANGA").upper()
+        collection_id = data.get("collection_id")
+        root_folder_id = data.get("root_folder_id")
         
         # Check if the series has a custom path
         custom_path = execute_query("SELECT custom_path FROM series WHERE id = ?", (series_id,))
@@ -227,23 +238,74 @@ def get_series_folder_path():
             # Create folder name that preserves spaces but replaces invalid characters
             safe_title = get_safe_folder_name(title)
             LOGGER.info(f"Original title: '{title}', Safe title for folder: '{safe_title}'")
-            
-            # Get root folders from settings
+
+            # Resolve preferred root folder without creating any directories
             from backend.internals.settings import Settings
-            from pathlib import Path
             settings = Settings().get_settings()
-            root_folders = settings.root_folders
-            
-            # If no root folders configured, use default ebook storage
-            if not root_folders:
-                # Get ebook storage directory
-                ebook_dir = get_ebook_storage_dir()
-                series_dir = ebook_dir / safe_title
-            else:
-                # Use the first root folder
-                root_folder = root_folders[0]
-                root_path = Path(root_folder['path'])
-                series_dir = root_path / safe_title
+
+            chosen_root_path = None
+
+            # 1) explicit root_folder_id
+            if root_folder_id:
+                try:
+                    rf = execute_query("SELECT path FROM root_folders WHERE id = ?", (int(root_folder_id),))
+                    if rf:
+                        chosen_root_path = Path(rf[0]['path'])
+                except Exception:
+                    pass
+
+            # 2) collection's root folders
+            if chosen_root_path is None and collection_id:
+                try:
+                    rows = execute_query(
+                        """
+                        SELECT rf.path FROM root_folders rf
+                        JOIN collection_root_folders crf ON rf.id = crf.root_folder_id
+                        WHERE crf.collection_id = ?
+                        ORDER BY rf.name ASC
+                        """,
+                        (int(collection_id),)
+                    )
+                    if rows:
+                        chosen_root_path = Path(rows[0]['path'])
+                except Exception:
+                    pass
+
+            # 3) default collection for type
+            if chosen_root_path is None:
+                try:
+                    rows = execute_query(
+                        """
+                        SELECT rf.path FROM root_folders rf
+                        JOIN collection_root_folders crf ON rf.id = crf.root_folder_id
+                        JOIN collections c ON c.id = crf.collection_id
+                        WHERE c.is_default = 1 AND UPPER(c.content_type) = ?
+                        ORDER BY rf.name ASC
+                        """,
+                        (content_type.upper(),)
+                    )
+                    if rows:
+                        chosen_root_path = Path(rows[0]['path'])
+                except Exception:
+                    pass
+
+            # 4) any settings root folder matching type
+            if chosen_root_path is None and settings.root_folders:
+                try:
+                    rf = next((rf for rf in settings.root_folders if (rf.get('content_type') or 'MANGA').upper() == content_type), None)
+                    if rf:
+                        chosen_root_path = Path(rf['path'])
+                except Exception:
+                    pass
+
+            # 5) fallback: first configured root folder or default ebooks dir
+            if chosen_root_path is None:
+                if settings.root_folders:
+                    chosen_root_path = Path(settings.root_folders[0]['path'])
+                else:
+                    chosen_root_path = get_ebook_storage_dir()
+
+            series_dir = chosen_root_path / safe_title
         
         # Return the folder path
         return jsonify({"folder_path": str(series_dir)})
@@ -394,6 +456,27 @@ def add_series():
         WHERE id = last_insert_rowid()
         """)
         
+        # Optionally link the series to a collection
+        try:
+            collection_id = data.get("collection_id")
+            if collection_id:
+                try:
+                    collection_id = int(collection_id)
+                except Exception:
+                    collection_id = None
+            if collection_id:
+                add_series_to_collection(collection_id, series_id)
+            else:
+                # Auto-link to default collection for the selected content_type if available
+                try:
+                    default_coll = get_default_collection(content_type)
+                    if default_coll and default_coll.get('id'):
+                        add_series_to_collection(default_coll['id'], series_id)
+                except Exception as _e:
+                    LOGGER.warning(f"Could not auto-link series to default collection: {_e}")
+        except Exception as link_err:
+            LOGGER.warning(f"Link to collection failed: {link_err}")
+
         # Create folder structure
         try:
             series_data = series[0]
@@ -411,8 +494,14 @@ def add_series():
             if not settings.root_folders:
                 LOGGER.warning("No root folders configured, using default ebook storage")
             else:
-                # Check if the first root folder exists
-                root_folder = settings.root_folders[0]
+                # Prefer a root folder that matches the collection type if possible (simple heuristic)
+                preferred_root = None
+                try:
+                    # find any root folder whose content_type matches selected content_type
+                    preferred_root = next((rf for rf in settings.root_folders if (rf.get('content_type') or 'MANGA').upper() == content_type), None)
+                except Exception:
+                    preferred_root = None
+                root_folder = preferred_root or settings.root_folders[0]
                 root_path = Path(root_folder['path'])
                 LOGGER.info(f"Root folder path: {root_path}, exists: {root_path.exists()}, is directory: {root_path.is_dir() if root_path.exists() else False}")
                 
@@ -430,7 +519,9 @@ def add_series():
             series_path = create_series_folder_structure(
                 series_data['id'],
                 series_data['title'],
-                series_data['content_type']
+                series_data['content_type'],
+                collection_id=data.get('collection_id'),
+                root_folder_id=data.get('root_folder_id')
             )
             
             LOGGER.info(f"Folder structure created at: {series_path}")

--- a/frontend/api_collections.py
+++ b/frontend/api_collections.py
@@ -92,6 +92,7 @@ def api_create_collection():
         name = data.get('name')
         description = data.get('description', '')
         is_default = data.get('is_default', False)
+        content_type = data.get('content_type', 'MANGA')
         
         if not name:
             return jsonify({
@@ -99,7 +100,7 @@ def api_create_collection():
                 "error": "Collection name is required"
             }), 400
         
-        collection_id = create_collection(name, description, is_default)
+        collection_id = create_collection(name, description, is_default, content_type)
         collection = get_collection_by_id(collection_id)
         
         return jsonify({
@@ -135,8 +136,9 @@ def api_update_collection(collection_id: int):
         name = data.get('name')
         description = data.get('description')
         is_default = data.get('is_default')
+        content_type = data.get('content_type')
         
-        updated = update_collection(collection_id, name, description, is_default)
+        updated = update_collection(collection_id, name, description, is_default, content_type)
         if not updated:
             return jsonify({
                 "success": True,
@@ -192,7 +194,9 @@ def api_delete_collection(collection_id: int):
 def api_get_default_collection():
     """Get the default collection."""
     try:
-        collection = get_default_collection()
+        # Optional query parameter: content_type (e.g., MANGA, COMICS, BOOK)
+        ct = request.args.get('content_type')
+        collection = get_default_collection(ct)
         return jsonify({
             "success": True,
             "collection": collection

--- a/frontend/api_metadata_fixed.py
+++ b/frontend/api_metadata_fixed.py
@@ -225,12 +225,20 @@ def api_import_manga(provider, manga_id):
     from backend.base.logging import LOGGER
     
     try:
-        # Get collection_id from request if provided
+        # Get optional overrides from request
         data = request.json or {}
         collection_id = data.get('collection_id')
+        content_type = data.get('content_type')
+        root_folder_id = data.get('root_folder_id')
         
-        # Import the manga
-        result = import_manga_to_collection(manga_id, provider)
+        # Import the manga, passing optional parameters
+        result = import_manga_to_collection(
+            manga_id,
+            provider,
+            collection_id=collection_id,
+            content_type=content_type,
+            root_folder_id=root_folder_id,
+        )
         
         if not result.get("success", False):
             # Check if it's because the series already exists

--- a/frontend/static/js/collections_manager.js
+++ b/frontend/static/js/collections_manager.js
@@ -40,12 +40,12 @@ function loadCollections() {
                 displayCollections(response.collections);
             } else {
                 console.error('Error loading collections:', response);
-                $('#collectionsTableBody').html('<tr><td colspan="6" class="text-center text-danger">Failed to load collections</td></tr>');
+                $('#collectionsTableBody').html('<tr><td colspan="7" class="text-center text-danger">Failed to load collections</td></tr>');
             }
         },
         error: function(xhr, status, error) {
             console.error('Error loading collections:', error);
-            $('#collectionsTableBody').html('<tr><td colspan="6" class="text-center text-danger">Failed to load collections</td></tr>');
+            $('#collectionsTableBody').html('<tr><td colspan="7" class="text-center text-danger">Failed to load collections</td></tr>');
         }
     });
     
@@ -61,7 +61,7 @@ function displayCollections(collections) {
     tbody.empty();
     
     if (collections.length === 0) {
-        tbody.html('<tr><td colspan="6" class="text-center">No collections found</td></tr>');
+        tbody.html('<tr><td colspan="7" class="text-center">No collections found</td></tr>');
         return;
     }
     
@@ -73,13 +73,16 @@ function displayCollections(collections) {
         
         // Description
         row.append($('<td>').text(collection.description || '-'));
+
+        // Type
+        row.append($('<td>').text(collection.content_type || 'MANGA'));
         
         // Root Folders count
-        const rootFoldersCount = collection.root_folders ? collection.root_folders.length : 0;
+        const rootFoldersCount = (typeof collection.root_folder_count === 'number') ? collection.root_folder_count : (collection.root_folders ? collection.root_folders.length : 0);
         row.append($('<td>').text(rootFoldersCount));
         
         // Series count
-        const seriesCount = collection.series ? collection.series.length : 0;
+        const seriesCount = (typeof collection.series_count === 'number') ? collection.series_count : (collection.series ? collection.series.length : 0);
         row.append($('<td>').text(seriesCount));
         
         // Default
@@ -453,6 +456,7 @@ function saveCollection() {
     const name = $('#collectionName').val().trim();
     const description = $('#collectionDescription').val().trim();
     const isDefault = $('#collectionIsDefault').is(':checked');
+    const contentType = $('#collectionContentType').val();
     
     if (!name) {
         alert('Collection name is required');
@@ -471,7 +475,8 @@ function saveCollection() {
         data: JSON.stringify({
             name: name,
             description: description,
-            is_default: isDefault
+            is_default: isDefault,
+            content_type: contentType
         }),
         success: function(response) {
             if (response.success) {
@@ -513,6 +518,7 @@ function editCollection(collection) {
     $('#editCollectionName').val(collection.name);
     $('#editCollectionDescription').val(collection.description || '');
     $('#editCollectionIsDefault').prop('checked', collection.is_default);
+    $('#editCollectionContentType').val(collection.content_type || 'MANGA');
     
     // Show the modal
     $('#editCollectionModal').modal('show');
@@ -526,6 +532,7 @@ function updateCollection() {
     const name = $('#editCollectionName').val().trim();
     const description = $('#editCollectionDescription').val().trim();
     const isDefault = $('#editCollectionIsDefault').is(':checked');
+    const contentType = $('#editCollectionContentType').val();
     
     if (!name) {
         alert('Collection name is required');
@@ -544,7 +551,8 @@ function updateCollection() {
         data: JSON.stringify({
             name: name,
             description: description,
-            is_default: isDefault
+            is_default: isDefault,
+            content_type: contentType
         }),
         success: function(response) {
             if (response.success) {

--- a/frontend/templates/about.html
+++ b/frontend/templates/about.html
@@ -106,7 +106,7 @@
                                 </ul>
                                 
                                 <p class="mt-3">
-                                    <a href="https://github.com/Darius-Codes/Readloom/blob/main/LEGAL.md" target="_blank" class="btn btn-sm btn-outline-primary">
+                                    <a href="https://github.com/Darius662/Readloom/blob/master/LEGAL.md" target="_blank" class="btn btn-sm btn-outline-primary">
                                         <i class="bi bi-file-text"></i> Read Full Legal Information
                                     </a>
                                 </p>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -279,7 +279,7 @@
             
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <small>v0.1.2-1</small>
+                    <small>v0.1.2-2</small>
                 </div>
             </div>
         </nav>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -279,7 +279,7 @@
             
             <div class="sidebar-footer">
                 <div class="version-info">
-                    <small>v0.1.1-1</small>
+                    <small>v0.1.2-1</small>
                 </div>
             </div>
         </nav>

--- a/frontend/templates/collections_manager.html
+++ b/frontend/templates/collections_manager.html
@@ -56,6 +56,7 @@
                                         <tr>
                                             <th>Name</th>
                                             <th>Description</th>
+                                            <th>Type</th>
                                             <th>Root Folders</th>
                                             <th>Series</th>
                                             <th>Default</th>
@@ -64,7 +65,7 @@
                                     </thead>
                                     <tbody id="collectionsTableBody">
                                         <tr>
-                                            <td colspan="6" class="text-center">Loading collections...</td>
+                                            <td colspan="7" class="text-center">Loading collections...</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -173,6 +174,14 @@
                         <label for="collectionDescription" class="form-label">Description</label>
                         <textarea class="form-control" id="collectionDescription" rows="3"></textarea>
                     </div>
+                    <div class="mb-3">
+                        <label for="collectionContentType" class="form-label">Content Type</label>
+                        <select class="form-select" id="collectionContentType">
+                            <option value="MANGA">Manga</option>
+                            <option value="COMIC">Comic</option>
+                            <option value="BOOK">Book</option>
+                        </select>
+                    </div>
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="collectionIsDefault">
                         <label class="form-check-label" for="collectionIsDefault">Set as default collection</label>
@@ -205,6 +214,14 @@
                     <div class="mb-3">
                         <label for="editCollectionDescription" class="form-label">Description</label>
                         <textarea class="form-control" id="editCollectionDescription" rows="3"></textarea>
+                    </div>
+                    <div class="mb-3">
+                        <label for="editCollectionContentType" class="form-label">Content Type</label>
+                        <select class="form-select" id="editCollectionContentType">
+                            <option value="MANGA">Manga</option>
+                            <option value="COMIC">Comic</option>
+                            <option value="BOOK">Book</option>
+                        </select>
                     </div>
                     <div class="mb-3 form-check">
                         <input type="checkbox" class="form-check-input" id="editCollectionIsDefault">

--- a/frontend/templates/search.html
+++ b/frontend/templates/search.html
@@ -65,6 +65,29 @@
                     <div class="col-md-4 mb-3">
                         <img id="modalCover" src="" alt="E-book Cover" class="img-fluid rounded">
                         <div class="mt-3">
+                            <div class="mb-2">
+                                <label class="form-label small mb-1">Content Type</label>
+                                <select id="modalContentType" class="form-select form-select-sm">
+                                    <option value="MANGA">Manga</option>
+                                    <option value="MANHWA">Manhwa</option>
+                                    <option value="MANHUA">Manhua</option>
+                                    <option value="COMICS">Comics</option>
+                                    <option value="NOVEL">Novel</option>
+                                    <option value="BOOK">Book</option>
+                                    <option value="OTHER">Other</option>
+                                </select>
+                            </div>
+                            <!-- Collection is auto-selected by content type; hidden from UI -->
+                            <div class="mb-2 d-none">
+                                <label class="form-label small mb-1">Collection</label>
+                                <select id="modalCollection" class="form-select form-select-sm" disabled></select>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label small mb-1">Root Folder (if collection has multiple)</label>
+                                <select id="modalRootFolder" class="form-select form-select-sm" disabled>
+                                    <option value="">-- Auto --</option>
+                                </select>
+                            </div>
                             <button id="btnAddToCollection" class="btn btn-success w-100 mb-2">
                                 <i class="fas fa-plus-circle me-2"></i> Add to Collection
                             </button>
@@ -220,6 +243,14 @@
                     if (totalResults === 0) {
                         $('#noResults').removeClass('d-none');
                     }
+                    // Try to infer type lightly from genres/description
+                    const blob = (Array.isArray(data.genres)? data.genres.join(' '): '') + ' ' + (data.description||'') + ' ' + (data.title||'');
+                    let inferred = 'MANGA';
+                    const lower = blob.toLowerCase();
+                    if (/(graphic\s*novel|comic|comics|bd\s)/.test(lower)) inferred = 'COMIC';
+                    if (/(manga|manhwa|manhua|shonen|seinen|shojo|shoujo)/.test(lower)) inferred = 'MANGA';
+                    $('#modalContentType').val(inferred);
+                    autoSelectDefaultForType(inferred);
                 },
                 error: function(xhr) {
                     $('#loadingIndicator').addClass('d-none');
@@ -263,6 +294,59 @@
             `;
         }
         
+        // Cached collections for selectors
+        let allCollections = [];
+        function loadCollections() {
+            return $.get('/api/collections').then(function(resp){
+                allCollections = (resp && resp.success && Array.isArray(resp.collections)) ? resp.collections : [];
+                populateCollectionsSelect();
+            }).catch(function(){ allCollections = []; populateCollectionsSelect(); });
+        }
+        function mapSubtypeToBucket(ct){
+            const v = (ct||'').toString().toUpperCase();
+            if (["MANGA","MANHWA","MANHUA"].includes(v)) return "MANGA";
+            if (["COMIC","COMICS"].includes(v)) return "COMIC";
+            if (["BOOK","BOOKS","NOVEL","OTHER"].includes(v)) return "BOOK";
+            return "MANGA";
+        }
+        function populateCollectionsSelect(){
+            const $sel = $('#modalCollection');
+            $sel.empty();
+            // group by content_type and mark default
+            const groups = {};
+            allCollections.forEach(c=>{
+                const ct = (c.content_type || 'MANGA').toUpperCase();
+                (groups[ct] ||= []).push(c);
+            });
+            Object.keys(groups).sort().forEach(ct=>{
+                const og = $(`<optgroup label="${ct}"></optgroup>`);
+                groups[ct].sort((a,b)=>a.name.localeCompare(b.name)).forEach(c=>{
+                    og.append(`<option value="${c.id}">${c.name}${c.is_default? ' (default)':''}</option>`);
+                });
+                $sel.append(og);
+            });
+            autoSelectDefaultForType($('#modalContentType').val());
+        }
+        function autoSelectDefaultForType(ct){
+            const bucket = mapSubtypeToBucket(ct);
+            const m = allCollections.find(c=> (c.content_type||'MANGA').toUpperCase() === bucket && c.is_default === 1);
+            $('#modalCollection').val(m? String(m.id):'');
+            // load root folders for default collection silently
+            loadRootFoldersForCollection($('#modalCollection').val());
+        }
+        function loadRootFoldersForCollection(collectionId){
+            const $rf = $('#modalRootFolder');
+            $rf.prop('disabled', true).empty().append('<option value="">-- Auto --</option>');
+            if (!collectionId) return;
+            $.get(`/api/collections/${collectionId}/root-folders`).then(function(resp){
+                const rfs = (resp && resp.success && Array.isArray(resp.root_folders))? resp.root_folders : [];
+                if (rfs.length>0){
+                    rfs.forEach(r=> $rf.append(`<option value="${r.id}">${r.name} (${r.path})</option>`));
+                    $rf.prop('disabled', false);
+                }
+            });
+        }
+
         // View e-book details
         $(document).on('click', '.view-details', function() {
             const ebookId = $(this).data('ebook-id');
@@ -284,6 +368,9 @@
             $('#btnAddToCollection').data('ebook-id', ebookId);
             $('#btnAddToCollection').data('provider', provider);
             
+            // Ensure selectors are populated
+            loadCollections();
+
             // Show modal
             const ebookModal = new bootstrap.Modal(document.getElementById('ebookDetailsModal'));
             ebookModal.show();
@@ -343,6 +430,12 @@
             });
         });
         
+        // When content type changes, re-auto-select default collection group
+        $(document).on('change', '#modalContentType', function(){
+            autoSelectDefaultForType($(this).val());
+        });
+        // Collection changes are internal only; no user control
+
         // View chapters button click
         $('#btnViewChapters').on('click', function() {
             const ebookId = $('#btnAddToCollection').data('ebook-id');
@@ -402,12 +495,16 @@
             const originalText = $btn.html();
             $btn.prop('disabled', true).html('<i class="fas fa-spinner fa-spin me-2"></i> Adding...');
             
-            // Import e-book to collection
+            // Import e-book to collection with selectors
             $.ajax({
                 url: `/api/metadata/import/${provider}/${ebookId}`,
                 method: 'POST',
                 contentType: 'application/json',
-                data: JSON.stringify({}),
+                data: JSON.stringify({
+                    content_type: $('#modalContentType').val(),
+                    collection_id: $('#modalCollection').val() || null,
+                    root_folder_id: $('#modalRootFolder').val() || null,
+                }),
                 success: function(data) {
                     // Reset button
                     $btn.prop('disabled', false).html(originalText);

--- a/frontend/templates/series_detail.html
+++ b/frontend/templates/series_detail.html
@@ -21,6 +21,49 @@
     </div>
 </div>
 
+<!-- Move Series Modal -->
+<div class="modal fade" id="moveSeriesModal" tabindex="-1" aria-labelledby="moveSeriesModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="moveSeriesModalLabel">Move Series</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <form id="move-series-form">
+                    <div class="mb-3">
+                        <label for="move-target-collection" class="form-label">Target Collection</label>
+                        <select class="form-select" id="move-target-collection"></select>
+                        <div class="form-text">Only collections in the same bucket as this series are listed.</div>
+                    </div>
+                    <div class="mb-3">
+                        <label for="move-target-root-folder" class="form-label">Target Root Folder (optional)</label>
+                        <select class="form-select" id="move-target-root-folder">
+                            <option value="">Auto-select first root folder</option>
+                        </select>
+                    </div>
+                    <div class="form-check form-switch mb-2">
+                        <input class="form-check-input" type="checkbox" id="move-files-switch">
+                        <label class="form-check-label" for="move-files-switch">Physically move files</label>
+                    </div>
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" type="checkbox" id="clear-custom-path-switch">
+                        <label class="form-check-label" for="clear-custom-path-switch">Clear custom path after move</label>
+                    </div>
+                    <div class="border rounded p-2 bg-light">
+                        <div class="small text-muted">Dry Run Preview</div>
+                        <pre id="move-dryrun-output" class="mb-0" style="white-space: pre-wrap; max-height: 200px; overflow:auto;">No plan yet</pre>
+                    </div>
+                </form>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary" id="move-dryrun-btn">Preview (Dry Run)</button>
+                <button type="button" class="btn btn-primary" id="move-execute-btn">Execute Move</button>
+            </div>
+        </div>
+    </div>
+ </div>
+
 <div class="row mb-4" id="volumes-container" style="display: none;">
     <div class="col-md-12">
         <div class="card">
@@ -310,6 +353,18 @@
     .ebook-file-container {
         width: 100%;
     }
+
+    /* Move button styling to ensure visibility next to Edit */
+    #move-series-btn {
+        height: 38px;
+        padding: 6px 10px;
+        margin: 10px 0;
+        z-index: 100;
+        box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+    }
     
     .ebook-file-item {
         display: flex;
@@ -412,6 +467,8 @@
                     seriesData = data.series;
                     volumesData = data.volumes;
                     chaptersData = data.chapters;
+                    // Expose globally for event handlers
+                    try { window.currentSeries = seriesData; } catch (e) {}
                     
                     displaySeriesDetails();
                     displayVolumes();
@@ -423,6 +480,173 @@
                     $('#series-details').html('<div class="col-12 text-center text-danger">Failed to load series data</div>');
                 }
             });
+
+            // Move button handler (delegated to work with dynamic content)
+            $(document).off('click', '#move-series-btn').on('click', '#move-series-btn', function(e) {
+                e.preventDefault();
+                console.log('Move button clicked');
+                const modalEl = document.getElementById('moveSeriesModal');
+                let modal = null;
+                try {
+                    if (window.bootstrap && bootstrap.Modal) {
+                        modal = new bootstrap.Modal(modalEl);
+                    }
+                } catch (err) {
+                    console.warn('Bootstrap Modal init failed, will try jQuery .modal("show")', err);
+                }
+                // Reset preview
+                $('#move-dryrun-output').text('No plan yet');
+                $('#move-files-switch').prop('checked', false);
+                $('#clear-custom-path-switch').prop('checked', false);
+                // Use the globally loaded seriesData in this handler
+                const series = (typeof window !== 'undefined' && window.currentSeries) ? window.currentSeries : seriesData;
+                if (!series || !series.id) {
+                    console.error('Series data not ready');
+                    if (typeof showToast === 'function') { showToast('Move', 'Series data not loaded yet', 'warning'); }
+                    return;
+                }
+
+                // Normalize bucket helper
+                const normBucket = (t) => {
+                    const u = (t || 'MANGA').toString().toUpperCase();
+                    if (u === 'COMICS') return 'COMIC';
+                    if (u === 'COMIC') return 'COMIC';
+                    if (u === 'BOOKS') return 'BOOK';
+                    if (u === 'NOVEL' || u === 'NOVELS') return 'BOOK';
+                    if (u === 'MANGA' || u === 'MANHWA' || u === 'MANHUA') return 'MANGA';
+                    return u;
+                };
+
+                const seriesBucket = normBucket(series.content_type);
+
+                // Load target collections and current memberships (dry-run to get before_collections)
+                Promise.all([
+                    fetch('/api/collections').then(r => r.json()),
+                    fetch(`/api/series/${series.id}/move`, {
+                        method: 'POST', headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ dry_run: true })
+                    }).then(r => r.json()).catch(() => ({ result: { before_collections: [] }}))
+                ]).then(([payload, moveInfo]) => {
+                    const allCols = payload.collections || [];
+                    const currentCols = (moveInfo && moveInfo.result && moveInfo.result.before_collections) ? moveInfo.result.before_collections : [];
+
+                    // Filter: same-bucket OR in current memberships (to always show current collection)
+                    const allowed = allCols.filter(c => {
+                        const b = normBucket(c.content_type);
+                        const sameBucket = b === seriesBucket;
+                        const isCurrent = currentCols.some(cc => cc.id === c.id);
+                        return sameBucket || isCurrent;
+                    });
+
+                    const select = $('#move-target-collection');
+                    select.empty();
+                    if (allowed.length === 0) {
+                        select.append('<option value="" disabled>No collections available</option>');
+                    } else {
+                        allowed.forEach(c => select.append(`<option value="${c.id}">${c.name}</option>`));
+                        // Preselect current collection if present
+                        const current = currentCols.length ? currentCols[0].id : null;
+                        if (current) select.val(String(current));
+                    }
+
+                    // Load root folders for selected collection
+                    loadRootFoldersForSelectedCollection();
+                }).catch(err => {
+                    console.error('Failed to init move collections', err);
+                });
+
+                // When collection changes, reload root folders
+                $('#move-target-collection').off('change').on('change', loadRootFoldersForSelectedCollection);
+
+                function loadRootFoldersForSelectedCollection() {
+                    const cid = $('#move-target-collection').val();
+                    const rfSelect = $('#move-target-root-folder');
+                    rfSelect.empty();
+                    rfSelect.append('<option value="">Auto-select first root folder</option>');
+                    if (!cid) return;
+                    fetch(`/api/collections/${cid}/root-folders`)
+                        .then(r => r.json())
+                        .then(payload => {
+                            (payload.root_folders || []).forEach(rf => rfSelect.append(`<option value="${rf.id}">${rf.name}</option>`));
+                        })
+                        .catch(err => console.error('Failed to load root folders', err));
+                }
+
+                // Dry run
+                $('#move-dryrun-btn').off('click').on('click', function() {
+                    const body = {
+                        target_collection_id: parseInt($('#move-target-collection').val() || '0', 10) || null,
+                        target_root_folder_id: parseInt($('#move-target-root-folder').val() || '0', 10) || null,
+                        move_files: $('#move-files-switch').is(':checked'),
+                        clear_custom_path: $('#clear-custom-path-switch').is(':checked'),
+                        dry_run: true
+                    };
+                    fetch(`/api/series/${series.id}/move`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(body)
+                    })
+                    .then(r => r.json())
+                    .then(resp => {
+                        if (resp.error) {
+                            $('#move-dryrun-output').text(`Error: ${resp.error}`);
+                            return;
+                        }
+                        $('#move-dryrun-output').text(JSON.stringify(resp.result, null, 2));
+                    })
+                    .catch(err => {
+                        $('#move-dryrun-output').text(`Error: ${err}`);
+                    });
+                });
+
+                // Execute move
+                $('#move-execute-btn').off('click').on('click', function() {
+                    const body = {
+                        target_collection_id: parseInt($('#move-target-collection').val() || '0', 10) || null,
+                        target_root_folder_id: parseInt($('#move-target-root-folder').val() || '0', 10) || null,
+                        move_files: $('#move-files-switch').is(':checked'),
+                        clear_custom_path: $('#clear-custom-path-switch').is(':checked'),
+                        dry_run: false
+                    };
+                    fetch(`/api/series/${series.id}/move`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify(body)
+                    })
+                    .then(r => r.json())
+                    .then(resp => {
+                        if (resp.error) {
+                            showToast('Move failed', resp.error, 'danger');
+                            return;
+                        }
+                        showToast('Move complete', 'Series has been moved successfully.', 'success');
+                        // Reload series data to reflect changes
+                        loadSeriesData();
+                        modal.hide();
+                    })
+                    .catch(err => {
+                        showToast('Move failed', String(err), 'danger');
+                    });
+                });
+
+                try {
+                    if (modal && modal.show) {
+                        modal.show();
+                    } else if (typeof $ !== 'undefined' && $('#moveSeriesModal').modal) {
+                        $('#moveSeriesModal').modal('show');
+                    } else {
+                        console.error('No modal show method available');
+                        if (typeof showToast === 'function') {
+                            showToast('Move', 'Unable to open Move dialog', 'danger');
+                        }
+                    }
+                } catch (err) {
+                    console.error('Error showing Move modal', err);
+                    if (typeof showToast === 'function') {
+                        showToast('Move', 'Error opening Move dialog', 'danger');
+                    }
+                }
+            });
         }
         
         // Display series details
@@ -431,7 +655,10 @@
             
             const html = `
                 <div class="position-relative">
-                    <div class="position-absolute top-0 end-0">
+                    <div class="position-absolute top-0 end-0 d-flex gap-2">
+                        <button class="btn btn-sm btn-outline-secondary rounded-circle" id="move-series-btn" title="Move Series" data-bs-toggle="modal" data-bs-target="#moveSeriesModal">
+                            <i class="fas fa-arrows-alt"></i>
+                        </button>
                         <button class="btn btn-sm btn-outline-primary rounded-circle" id="edit-series-btn" title="Edit Series">
                             <i class="fas fa-edit"></i>
                         </button>
@@ -1264,9 +1491,14 @@
                         <div class="card-footer bg-transparent">
                             <div class="d-flex justify-content-between align-items-center">
                                 <span class="text-muted small">Quick Actions</span>
+                                <div class="btn-group">
+                                <button class="btn btn-sm btn-outline-secondary" id="quick-move-series-btn" title="Move Series" data-bs-toggle="modal" data-bs-target="#moveSeriesModal">
+                                    <i class="fas fa-exchange-alt"></i> Move
+                                </button>
                                 <button class="btn btn-sm btn-primary" id="quick-scan-ebooks-btn">
                                     <i class="fas fa-search"></i> Scan for E-books
                                 </button>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -1364,6 +1596,12 @@
         // Set up quick scan button
         $('#quick-scan-ebooks-btn').click(function() {
             scanEbooks($(this));
+        });
+
+        // Quick move button uses same handler as header button
+        $(document).off('click', '#quick-move-series-btn').on('click', '#quick-move-series-btn', function(e) {
+            e.preventDefault();
+            $('#move-series-btn').trigger('click');
         });
         
         // Initial load

--- a/frontend/templates/series_list.html
+++ b/frontend/templates/series_list.html
@@ -79,6 +79,29 @@
                         </select>
                     </div>
                     <div class="mb-3">
+                        <label for="series-content-type" class="form-label">Content Type</label>
+                        <select class="form-select" id="series-content-type">
+                            <option value="MANGA">Manga</option>
+                            <option value="MANHWA">Manhwa</option>
+                            <option value="MANHUA">Manhua</option>
+                            <option value="COMICS">Comics</option>
+                            <option value="NOVEL">Novel</option>
+                            <option value="BOOK">Book</option>
+                            <option value="OTHER">Other</option>
+                        </select>
+                    </div>
+                    <!-- Collection auto-selected by content type; hidden from UI -->
+                    <div class="mb-3 d-none">
+                        <label for="series-collection" class="form-label">Collection</label>
+                        <select class="form-select" id="series-collection" disabled></select>
+                    </div>
+                    <div class="mb-3">
+                        <label for="series-root-folder" class="form-label">Root Folder (if collection has multiple)</label>
+                        <select class="form-select" id="series-root-folder" disabled>
+                            <option value="">-- Auto --</option>
+                        </select>
+                    </div>
+                    <div class="mb-3">
                         <label for="series-cover-url" class="form-label">Cover URL</label>
                         <input type="url" class="form-control" id="series-cover-url">
                     </div>
@@ -213,10 +236,100 @@
             displaySeries(filteredSeries);
         });
         
+        // Load all collections once and cache
+        let allCollections = [];
+        function loadCollectionsForModal() {
+            return $.get('/api/collections').then(function(resp) {
+                if (resp.success && resp.collections) {
+                    allCollections = resp.collections || [];
+                } else {
+                    allCollections = [];
+                }
+                populateCollectionSelect();
+            }).catch(function() {
+                allCollections = [];
+                populateCollectionSelect();
+            });
+        }
+
+        function populateCollectionSelect() {
+            const select = $('#series-collection');
+            select.empty();
+            // Group by content_type
+            const groups = {};
+            allCollections.forEach(c => {
+                const ct = (c.content_type || 'MANGA').toUpperCase();
+                if (!groups[ct]) groups[ct] = [];
+                groups[ct].push(c);
+            });
+            Object.keys(groups).sort().forEach(ct => {
+                const optgroup = $(`<optgroup label="${ct}"></optgroup>`);
+                groups[ct]
+                    .sort((a,b)=> a.name.localeCompare(b.name))
+                    .forEach(c => {
+                        const defaultMark = c.is_default ? ' (default)' : '';
+                        optgroup.append(`<option value="${c.id}">${c.name}${defaultMark}</option>`);
+                    });
+                select.append(optgroup);
+            });
+        }
+
+        function mapSubtypeToBucket(ct) {
+            const v = (ct||'').toString().toUpperCase();
+            if (["MANGA","MANHWA","MANHUA"].includes(v)) return "MANGA";
+            if (["COMIC","COMICS"].includes(v)) return "COMIC";
+            if (["BOOK","BOOKS","NOVEL","OTHER"].includes(v)) return "BOOK";
+            return "MANGA";
+        }
+        function autoSelectDefaultForType(ct) {
+            const type = mapSubtypeToBucket(ct);
+            // try to pick default of that type
+            const match = allCollections.find(c => (c.content_type || 'MANGA').toUpperCase() === type && c.is_default === 1);
+            if (match) {
+                $('#series-collection').val(String(match.id));
+                // load root folders for this default collection
+                loadRootFoldersForCollection(String(match.id));
+                return;
+            }
+            // otherwise clear selection
+            $('#series-collection').val('');
+            // and reset root folders
+            resetRootFolders();
+        }
+
+        function resetRootFolders() {
+            const $rf = $('#series-root-folder');
+            $rf.prop('disabled', true).empty().append('<option value="">-- Auto --</option>');
+        }
+
+        function loadRootFoldersForCollection(collectionId) {
+            const $rf = $('#series-root-folder');
+            resetRootFolders();
+            if (!collectionId) return;
+            $.get(`/api/collections/${collectionId}/root-folders`).then(function(resp){
+                const rfs = (resp && resp.success && Array.isArray(resp.root_folders)) ? resp.root_folders : [];
+                if (rfs.length > 0) {
+                    rfs.forEach(r => $rf.append(`<option value="${r.id}">${r.name} (${r.path})</option>`));
+                    $rf.prop('disabled', false);
+                }
+            });
+        }
+
         // Add series modal
         $('#add-series-btn').click(function() {
             const modal = new bootstrap.Modal(document.getElementById('addSeriesModal'));
-            modal.show();
+            // load collections and then show
+            loadCollectionsForModal().then(function() {
+                // default type MANGA
+                $('#series-content-type').val('MANGA');
+                autoSelectDefaultForType('MANGA');
+                modal.show();
+            });
+        });
+
+        // When content type changes, re-auto-select default collection for that type
+        $(document).on('change', '#series-content-type', function() {
+            autoSelectDefaultForType($(this).val());
         });
         
         // Save new series
@@ -234,7 +347,11 @@
                 publisher: $('#series-publisher').val(),
                 description: $('#series-description').val(),
                 status: $('#series-status').val(),
-                cover_url: $('#series-cover-url').val()
+                cover_url: $('#series-cover-url').val(),
+                content_type: $('#series-content-type').val(),
+                // collection auto-mapped by subtype bucket
+                collection_id: $('#series-collection').val() || null,
+                root_folder_id: $('#series-root-folder').val() || null,
             };
             
             // Disable button and show loading


### PR DESCRIPTION
#26 #28 #29 #30 
## [0.1.2] - 2025-10-04

### Added
- **Collections Manager**:
  - Link Root Folder button and modal in `Collections Manager` collection details
  - Modal lists only unlinked root folders for the selected collection
  - Frontend wiring to `POST /api/collections/{id}/root-folders/{root_folder_id}` and auto-refresh of the table
- **API Documentation**:
  - Documented `GET /api/collections/default` endpoint usage across the app
- **Expanded Content Types in UI**:
  - `frontend/templates/search.html` (Import modal) and `frontend/templates/series_list.html` (Add Series) now support: Manga, Manhwa, Manhua, Comics, Novel, Book, Other.
  - Implemented subtype-to-bucket mapping function to group these under collection buckets: `MANGA` (Manga/Manhwa/Manhua), `COMIC` (Comics), `BOOK` (Book/Novel/Other).
- **Root Folder Selection**:
  - Visible Root Folder selector added to both flows, populated from the auto-selected default collection for the chosen bucket.
  - Users can optionally choose a specific root folder when a collection has multiple.
 - **Series Move API**:
  - Added `POST /api/series/{id}/move` to move a series between collections within the same bucket (DB-only, no file moves yet).
  - Returns a summary of before/after collection memberships and whether a change occurred.
  - **Series Move Feature**:
  - Backend:
    - Added [move_service.py](cci:7://file:///c:/Users/dariu/Documents/GitHub/Readloom/backend/features/move_service.py:0:0-0:0) with full move operation support (DB + filesystem)
    - Dry-run mode to preview moves before executing
    - Bucket compatibility validation (MANGA/COMIC/BOOK)
  - API:
    - Extended `POST /api/series/{id}/move` endpoint with:
      - `target_collection_id` (required)
      - `target_root_folder_id` (optional)
      - `move_files` flag for physical moves
      - `clear_custom_path` option
      - `dry_run` mode
  - UI:
    - Added Move button in series header and Quick Actions
    - Interactive Move dialog with collection/folder selectors
    - Dry-run preview panel showing paths and conflicts
    - Safety checks to prevent destructive overwrites

### Fixed
- **Default Collection Handling**:
  - Ensured only one default collection is treated as active throughout UI flows
  - Consistent Default badge display in Collections Manager
  - Safer delete behavior for default collection and clearer UX around default selection
- **UnboundLocalError in folder path endpoint**:
  - `frontend/api.py`: removed inner import shadowing of `execute_query` and moved `Path` import to top-level to fix "cannot access local variable 'execute_query'" error in `get_series_folder_path()`.

### Changed
- **Docs**:
  - Updated `docs/COLLECTIONS.md` with the new Link Root Folder workflow and troubleshooting
  - Added `docs/LINK_ROOT_FOLDER.md` guide
- **Simplified Collection Selection UX**:
  - Collection selector is now hidden in both Import and Add Series flows and auto-selected to the single default collection per bucket.
  - Import/Add requests now include `content_type` (the selected subtype), resolved `collection_id` (default per bucket), and optional `root_folder_id`.
- **Type Inference on Details Modal**:
  - Light heuristics added in `search.html` to pre-select a sensible content subtype based on title/genres/description.

┆Issue is synchronized with this [Jira Task](https://homedsolutions.atlassian.net/browse/READ-22) by [Unito](https://www.unito.io)
